### PR TITLE
Allow routing multiple paths to the same websocket view func.

### DIFF
--- a/src/flask_sock/__init__.py
+++ b/src/flask_sock/__init__.py
@@ -54,49 +54,56 @@ class Sock:
                        for the ``app.route`` decorator for details.
         """
         def decorator(f):
-            @wraps(f)
-            def websocket_route(*args, **kwargs):  # pragma: no cover
-                ws = Server(request.environ, **current_app.config.get(
-                    'SOCK_SERVER_OPTIONS', {}))
-                try:
-                    f(ws, *args, **kwargs)
-                except ConnectionClosed:
-                    pass
-                try:
-                    ws.close()
-                except:  # noqa: E722
-                    pass
+            if hasattr(f, '__flask_sock_routed__'):
+                websocket_route = f
+            else:
+                @wraps(f)
+                def websocket_route(*args, **kwargs):
+                    ws = Server(request.environ, **current_app.config.get(
+                        'SOCK_SERVER_OPTIONS', {}))
+                    try:
+                        f(ws, *args, **kwargs)
+                    except ConnectionClosed:
+                        pass
+                    try:
+                        ws.close()
+                    except:  # noqa: E722
+                        pass
 
-                class WebSocketResponse(Response):
-                    def __call__(self, *args, **kwargs):
-                        if ws.mode == 'eventlet':
-                            try:
-                                from eventlet.wsgi import WSGI_LOCAL
-                                ALREADY_HANDLED = []
-                            except ImportError:
-                                from eventlet.wsgi import ALREADY_HANDLED
-                                WSGI_LOCAL = None
+                    class WebSocketResponse(Response):
+                        def __call__(self, *args, **kwargs):
+                            if ws.mode == 'eventlet':
+                                try:
+                                    from eventlet.wsgi import WSGI_LOCAL
+                                    ALREADY_HANDLED = []
+                                except ImportError:
+                                    from eventlet.wsgi import ALREADY_HANDLED
+                                    WSGI_LOCAL = None
 
-                            if hasattr(WSGI_LOCAL, 'already_handled'):
-                                WSGI_LOCAL.already_handled = True
-                            return ALREADY_HANDLED
-                        elif ws.mode == 'gunicorn':
-                            raise StopIteration()
-                        elif ws.mode == 'werkzeug':
-                            return super().__call__(*args, **kwargs)
-                        else:
-                            return []
+                                if hasattr(WSGI_LOCAL, 'already_handled'):
+                                    WSGI_LOCAL.already_handled = True
+                                return ALREADY_HANDLED
+                            elif ws.mode == 'gunicorn':
+                                raise StopIteration()
+                            elif ws.mode == 'werkzeug':
+                                return super().__call__(*args, **kwargs)
+                            else:
+                                return []
 
-                return WebSocketResponse()
+                    return WebSocketResponse()
 
             kwargs['websocket'] = True
             if bp:
-                bp.route(path, **kwargs)(websocket_route)
+                decorator_impl = bp.route(path, **kwargs)
             elif self.app:
-                self.app.route(path, **kwargs)(websocket_route)
+                decorator_impl = self.app.route(path, **kwargs)
             else:
                 if self.bp is None:  # pragma: no branch
                     self.bp = Blueprint('__flask_sock', __name__)
-                self.bp.route(path, **kwargs)(websocket_route)
+                decorator_impl = self.bp.route(path, **kwargs)
+
+            websocket_route = decorator_impl(websocket_route)
+            websocket_route.__flask_sock_routed__ = True
+            return websocket_route
 
         return decorator

--- a/tests/test_flask_sock.py
+++ b/tests/test_flask_sock.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest import mock
+
 from flask import Flask, Blueprint
 
 import flask_sock
@@ -63,3 +65,55 @@ class FlaskSockTestCase(unittest.TestCase):
         assert app.url_map._rules[0].websocket is True
         assert app.url_map._rules[1].rule == '/ws'
         assert app.url_map._rules[1].websocket is True
+
+    def test_decorator_wraps_properly(self):
+        app = Flask(__name__, static_folder=None)
+        sock = flask_sock.Sock(app)
+        route = sock.route('/ws')
+
+        def ws_func(ws):
+            pass
+
+        routed_ws_func = route(ws_func)
+
+        assert routed_ws_func.__wrapped__ is ws_func
+        assert routed_ws_func.__name__ == ws_func.__name__
+        assert routed_ws_func.__doc__ == ws_func.__doc__
+        assert app.url_map._rules[0].endpoint == 'ws_func'
+        assert app.view_functions['ws_func'] is routed_ws_func
+
+    def test_stacked_routes(self):
+        app = Flask(__name__, static_folder=None)
+        sock = flask_sock.Sock(app)
+
+        @sock.route('/ws')
+        @sock.route('/ws/<optional>')
+        def ws_func(ws, optional=None):
+            pass
+
+        assert app.url_map._rules[0].rule == '/ws/<optional>'
+        assert app.url_map._rules[0].endpoint == 'ws_func'
+        assert app.url_map._rules[1].rule == '/ws'
+        assert app.url_map._rules[1].endpoint == 'ws_func'
+
+    def test_client_request(self):
+        app = Flask(__name__, static_folder=None)
+        sock = flask_sock.Sock(app)
+        mock_ws = mock.Mock()
+        client = app.test_client()
+
+        def fake_simple_websocket_server(environ, **options):
+            mock_ws.mode = 'werkzeug'
+            return mock_ws
+
+        @sock.route('/ws/test')
+        def ws_func(ws):
+            assert ws is mock_ws
+            ws.test()
+
+        with mock.patch('flask_sock.Server', fake_simple_websocket_server):
+            assert mock_ws.mock_calls == []
+
+            client.open(method='GET', url_scheme='ws', path='/ws/test')
+
+            assert mock_ws.mock_calls == [mock.call.test(), mock.call.close()]


### PR DESCRIPTION
Flask supports stacking `@route` decorators to expose view funcs on multiple paths. This is often used to allow optional path components, eg:
```py
@route("/ws")
@route("/ws/<optional_param>")
def func(ws, optional_param=None):
    ...
```

`flask_sock.Socket.route()` did not support this stacking for a couple reasons. Let's fix that:
- Make `decorator()` return the newly-routed view func so it can be passed to the next (above) `@route()`.
- Set and check a sentinel (`__flask_sock_routed__`) to avoid double-wrapping view funcs.
  - We **do** want to apply the underlying `app.route()` multiple times, to register the view func at each path, but we don't want to inject multiple `ws` args.
  - Note to reviewers: Use Hide Whitespace; most of the `decorator()` change is just indentation for this.

## Dependencies
N/A

## Testing
- New unit tests.
- `tox` passes locally (skipped for 2 envs i dont have installed):
  ```
  $ tox
  ...
    flake8: OK (4.10=setup[3.76]+cmd[0.34] seconds)
    py38: SKIP (0.02 seconds)
    py39: OK (5.86=setup[2.56]+cmd[2.81,0.49] seconds)
    py310: OK (5.75=setup[2.74]+cmd[2.55,0.45] seconds)
    py311: OK (5.52=setup[2.64]+cmd[2.40,0.47] seconds)
    py312: OK (5.95=setup[2.63]+cmd[2.62,0.70] seconds)
    pypy3: SKIP (0.01 seconds)
    docs: OK (3.36=setup[2.69]+cmd[0.68] seconds)
    congratulations :) (30.65 seconds)
  ```
  - (I haven't figured out how to get GitHub actions to build it for the PR yet.)

## Launch
Steps: Merge